### PR TITLE
feat: add stripe credit top-up helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "stripe": "^14.23.0"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/lib/credits.ts
+++ b/src/lib/credits.ts
@@ -1,0 +1,34 @@
+import Stripe from 'stripe';
+import { doc, updateDoc, increment } from 'firebase/firestore';
+import { db } from './firebase';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
+  apiVersion: '2024-06-20',
+});
+
+/**
+ * Add credit to a user's account by charging a payment method via Stripe.
+ *
+ * @param userId - Firebase Auth user id
+ * @param paymentMethod - Stripe payment method id
+ * @param amount - Amount in cents to charge and add as credit
+ */
+export async function addCredit(
+  userId: string,
+  paymentMethod: string,
+  amount: number
+) {
+  const paymentIntent = await stripe.paymentIntents.create({
+    amount,
+    currency: 'usd',
+    payment_method: paymentMethod,
+    confirm: true,
+  });
+
+  if (paymentIntent.status === 'succeeded') {
+    const userRef = doc(db, 'users', userId);
+    await updateDoc(userRef, { credits: increment(amount) });
+  }
+
+  return paymentIntent;
+}

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,6 +1,7 @@
 
 import { initializeApp, getApps, getApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
 
 const firebaseConfig = {
   projectId: 'blaze-reborn',
@@ -14,5 +15,6 @@ const firebaseConfig = {
 // Initialize Firebase
 const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
 const auth = getAuth(app);
+const db = getFirestore(app);
 
-export { app, auth };
+export { app, auth, db };


### PR DESCRIPTION
## Summary
- export Firestore database instance
- add Stripe helper to charge user and update credits
- declare stripe dependency

## Testing
- `npm test` (fails: Missing script)
- `npm run typecheck` (fails: Cannot find module 'stripe')


------
https://chatgpt.com/codex/tasks/task_e_688fa15502f48324b53284d52c12fd26