### PR TITLE
feat: add firebase email auth helpers

### DIFF
--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -7,13 +7,9 @@ import * as z from 'zod';
 import Link from 'next/link';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { 
-  createUserWithEmailAndPassword, 
-  signInWithEmailAndPassword,
-  GoogleAuthProvider,
-  signInWithPopup
-} from 'firebase/auth';
+import { GoogleAuthProvider, signInWithPopup } from 'firebase/auth';
 import { auth } from '@/lib/firebase';
+import { signIn as signInWithEmail, signUp as signUpWithEmail } from '@/lib/auth';
 import { useToast } from '@/hooks/use-toast';
 
 import { Button } from '@/components/ui/button';
@@ -57,9 +53,9 @@ export function AuthForm({ mode }: AuthFormProps) {
     setIsLoading(true);
     try {
       if (mode === 'register') {
-        await createUserWithEmailAndPassword(auth, values.email, values.password);
+        await signUpWithEmail(values.email, values.password);
       } else {
-        await signInWithEmailAndPassword(auth, values.email, values.password);
+        await signInWithEmail(values.email, values.password);
       }
       router.push('/');
       toast({

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,24 @@
+import { createUserWithEmailAndPassword, signInWithEmailAndPassword, UserCredential } from 'firebase/auth';
+import { auth } from './firebase';
+
+/**
+ * Register a new user with email and password.
+ *
+ * @param email - User email address
+ * @param password - User password
+ * @returns Firebase UserCredential for the newly created user
+ */
+export function signUp(email: string, password: string): Promise<UserCredential> {
+  return createUserWithEmailAndPassword(auth, email, password);
+}
+
+/**
+ * Sign in an existing user with email and password.
+ *
+ * @param email - User email address
+ * @param password - User password
+ * @returns Firebase UserCredential for the signed in user
+ */
+export function signIn(email: string, password: string): Promise<UserCredential> {
+  return signInWithEmailAndPassword(auth, email, password);
+}


### PR DESCRIPTION
## Summary
- centralize Firebase email sign-up and sign-in in reusable helpers
- refactor auth form to use the new helpers

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: prompts for configuration)
- `npm run typecheck` (fails: Type '"2024-06-20"' is not assignable to type '"2023-10-16"')

------
https://chatgpt.com/codex/tasks/task_e_688fa49f3f788324b3e5db3a342e7b3e